### PR TITLE
pugixml support in CMake

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "sources/3rdParty/catch"]
 	path = sources/3rdParty/catch
 	url = https://github.com/philsquared/Catch
+[submodule "sources/3rdParty/pugixml"]
+	path = sources/3rdParty/pugixml
+	url = https://github.com/zeux/pugixml

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,6 @@ before_script:
   - cd ./sources
 
 script:
-  - cmake .
+  - cmake -DUSE_STATIC_PUGIXML=ON -DCMAKE_BUILD_TYPE=Release .
   - make
   - make check

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -66,3 +66,5 @@ include(commonUtTarget)
 include(unitTests)
 
 include(doxygen)
+
+include(pugixml)

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -34,6 +34,8 @@
 
 cmake_minimum_required(VERSION 3.0)
 
+include(FeatureSummary)
+
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 include(version)
@@ -68,3 +70,5 @@ include(unitTests)
 include(doxygen)
 
 include(pugixml)
+
+feature_summary(WHAT ALL)

--- a/sources/cmake/comparisonTest.cmake
+++ b/sources/cmake/comparisonTest.cmake
@@ -27,7 +27,7 @@
 find_package(PythonInterp 3.5)
 set_package_properties(PythonInterp PROPERTIES
                        URL "http://python.org"
-                       DESCRIPTION "Python programming language interpretter"
+                       DESCRIPTION "Python programming language interpreter"
                        TYPE OPTIONAL
                        PURPOSE "Enables comparison test.")
 

--- a/sources/cmake/comparisonTest.cmake
+++ b/sources/cmake/comparisonTest.cmake
@@ -25,6 +25,11 @@
 # Comparison functional test.
 
 find_package(PythonInterp 3.5)
+set_package_properties(PythonInterp PROPERTIES
+                       URL "http://python.org"
+                       DESCRIPTION "Python programming language interpretter"
+                       TYPE OPTIONAL
+                       PURPOSE "Enables comparison test.")
 
 if (PYTHONINTERP_FOUND)
     set(COMPARISON_TEST_SCRIPT ${ROOT_DIR}/test/functional/comparison_test.py)

--- a/sources/cmake/doxygen.cmake
+++ b/sources/cmake/doxygen.cmake
@@ -25,6 +25,11 @@
 # Add Doxygen target.
 
 find_package(Doxygen)
+set_package_properties(Doxygen PROPERTIES
+                       URL "http://doxygen.org"
+                       DESCRIPTION "Tool for generating documentation from annotated C++ sources"
+                       TYPE OPTIONAL
+                       PURPOSE "Enables generation of code documentation.")
 
 if (DOXYGEN_FOUND)
   set(DOXYFILE_IN ${DEVEL_SUPPORT_DIR}/config/Doxyfile.in)

--- a/sources/cmake/install.cmake
+++ b/sources/cmake/install.cmake
@@ -24,16 +24,18 @@
 
 # Set installation.
 
+include(GNUInstallDirs)
+
 install(TARGETS vcdMaker vcdMerge
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         COMPONENT runtime)
 
 install(FILES ${MAN_PAGES_GENERATED}
-        DESTINATION share/man/man1
+        DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
         COMPONENT documentation)
 
 install(DIRECTORY common/doc/
-        DESTINATION share/doc/${CMAKE_PROJECT_NAME}
+        DESTINATION ${CMAKE_INSTALL_DOCDIR}
         COMPONENT documentation
         PATTERN "*.odt" EXCLUDE
         PATTERN "man" EXCLUDE)

--- a/sources/cmake/pugixml.cmake
+++ b/sources/cmake/pugixml.cmake
@@ -22,7 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-option(USE_STATIC_PUGIXML "Set to ON to build and static link pugixml library, set to OFF to use system library" OFF)
+option(USE_STATIC_PUGIXML "Set to ON to build and static link pugixml library, set to OFF to use system library." OFF)
+add_feature_info(StaticPugixml USE_STATIC_PUGIXML "Enables usage of source based, bundled pugixml library.")
 
 if (USE_STATIC_PUGIXML)
     set(PUGIXML_OUTPUT_DIR ${OUTPUT_DIR_ABSOLUE}/pugixml)
@@ -60,6 +61,11 @@ if (USE_STATIC_PUGIXML)
      set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${PUGIXML_LIB_FILE})
 else()
     find_package(pugixml REQUIRED)
+    set_package_properties(pugixml PROPERTIES
+                           URL "http://pugixml.org"
+                           DESCRIPTION "Light-weight C++ XML processing library."
+                           TYPE REQUIRED
+                           PURPOSE "Enables parsing of XML files.")
 endif()
 
 target_link_libraries(vcdMaker pugixml)

--- a/sources/cmake/pugixml.cmake
+++ b/sources/cmake/pugixml.cmake
@@ -1,0 +1,66 @@
+# pugixml.cmake
+#
+# Pugixml library support.
+#
+# Copyright (c) 2017 vcdMaker team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+option(USE_STATIC_PUGIXML "Set to ON to build and static link pugixml library, set to OFF to use system library" OFF)
+
+if (USE_STATIC_PUGIXML)
+    set(PUGIXML_OUTPUT_DIR ${OUTPUT_DIR_ABSOLUE}/pugixml)
+    set(PUGIXML_INSTALL_DIR ${PUGIXML_OUTPUT_DIR}/install)
+
+    include(ExternalProject)
+    ExternalProject_Add(pugixml_project
+                        SOURCE_DIR ${PROJECT_SOURCE_DIR}/3rdParty/pugixml
+                        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${PUGIXML_INSTALL_DIR} -DCMAKE_BUILD_TYPE=Release
+                        BUILD_IN_SOURCE OFF
+                        BINARY_DIR ${PUGIXML_OUTPUT_DIR}
+                        INSTALL_DIR ${PUGIXML_INSTALL_DIR}
+                        TMP_DIR ${PUGIXML_OUTPUT_DIR}/tmp
+                        STAMP_DIR ${PUGIXML_OUTPUT_DIR}/stamp)
+
+    add_dependencies(vcdMaker pugixml_project)
+    add_dependencies(vcdMerge pugixml_project)
+
+    add_library(pugixml STATIC IMPORTED)
+
+    if(WIN32)
+        set(LIB_PREFIX "")
+        set(LIB_SUFFIX ".lib")
+    else()
+        set(LIB_PREFIX "lib")
+        set(LIB_SUFFIX ".a")
+    endif()
+
+    set(PUGIXML_LIB_FILE ${PUGIXML_OUTPUT_DIR}/${LIB_PREFIX}pugixml${LIB_SUFFIX})
+
+    set_target_properties(pugixml PROPERTIES
+                          IMPORTED_LOCATION ${PUGIXML_LIB_FILE}
+                          INTERFACE_INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/3rdParty/pugixml/src)
+
+     set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${PUGIXML_LIB_FILE})
+else()
+    find_package(pugixml REQUIRED)
+endif()
+
+target_link_libraries(vcdMaker pugixml)
+target_link_libraries(vcdMerge pugixml)


### PR DESCRIPTION
**This must be merged before #25 and #25 needs to be modified to use this.**

Allows to select statically built pugixml (from git submodule) or system-wide library.

We need to decide how we want to build our packages and installers... I would say that for Windows we always should use static pugixml. For Linux packages we may try to use system libraries (and add dependencies to packages).

I have also noticed that Travis uses super-old Ubuntu version. Because of that I think we should use static pugixml there.